### PR TITLE
Upgrade to can-type 0.2.0 to support late types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "can-reflect": "^1.17.9",
     "can-simple-observable": "^2.4.1",
     "can-string-to-any": "^1.2.0",
-    "can-type": "^0.1.13"
+    "can-type": "^0.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/define.js
+++ b/src/define.js
@@ -836,7 +836,7 @@ makeDefinition = function(prop, def, defaultDefinition, typePrototype) {
 				return serialize.call(val);
 			};
 		}
-		definition.type = define.normalizeTypeDefinition(value);
+		definition.type = type.normalize(value);
 	}
 
 	var noTypeDefined = !definition.type && (!defaultDefinition.type ||
@@ -844,11 +844,11 @@ makeDefinition = function(prop, def, defaultDefinition, typePrototype) {
 
 	if (definition.hasOwnProperty("default")) {
 		if (typeof definition.default === "function" && !definition.default.isAGetter && noTypeDefined) {
-			definition.type = type.check(Function);
+			definition.type = type.normalize(Function);
 		}
 
 		if (canReflect.isPrimitive(definition.default) && noTypeDefined) {
-			definition.type = type.check(definition.default.constructor);
+			definition.type = type.normalize(definition.default.constructor);
 		}
 	}
 
@@ -881,7 +881,7 @@ getDefinitionOrMethod = function(prop, value, defaultDefinition, typePrototype){
 			// only include type from defaultDefininition
 			// if it came from propertyDefaults
 			type: defaultDefinition.typeSetByDefault ?
-				type.check(value.constructor) :
+				type.normalize(value.constructor) :
 				defaultDefinition.type
 		};
 	}
@@ -890,12 +890,12 @@ getDefinitionOrMethod = function(prop, value, defaultDefinition, typePrototype){
 		if(value[isMemberSymbol]) {
 			definition = { type: value };
 		} else {
-			definition = { type: type.check(value) };
+			definition = { type: type.normalize(value) };
 		}
 	}
 	else if(typeof value === "function") {
 		if(canReflect.isConstructorLike(value)) {
-			definition = { type: type.check(value) };
+			definition = { type: type.normalize(value) };
 		} else {
 			definition = { default: value, type: Function };
 		}
@@ -1078,23 +1078,8 @@ var returnFirstArg = function(arg){
 	return arg;
 };
 
-define.normalizeTypeDefinition = function normalizeTypeDefinition (value) {
-	// normalize type that implements can.new
-	if(value[newSymbol]) {
-		if(value[isMemberSymbol]) {
-			return value;
-		} else {
-			return type.check(value);
-		}
-	}
-
-	// normalize type that is a built-in constructor
-	else if (canReflect.isConstructorLike(value)) {
-		return type.check(value);
-	}
-
-	return value;
-};
+// TODO Why is this exported, does it need to be?
+define.normalizeTypeDefinition = type.normalize;
 
 define.expando = function(map, prop, value) {
 	if(define._specialKeys[prop]) {
@@ -1289,5 +1274,5 @@ define.hooks = {
 		//!steal-remove-end
 	},
 	expando: define.expando,
-	normalizeTypeDefinition: define.normalizeTypeDefinition
+	normalizeTypeDefinition: type.normalize //define.normalizeTypeDefinition
 };

--- a/test/props-mixin-proxy-object-test.js
+++ b/test/props-mixin-proxy-object-test.js
@@ -3,6 +3,7 @@ const addDefinedProps = require("../src/define");
 const { hooks } = addDefinedProps;
 const canReflect = require("can-reflect");
 const ObservationRecorder = require("can-observation-recorder");
+const type = require("can-type");
 
 const DefineObject = mixinObject();
 
@@ -80,4 +81,21 @@ QUnit.test("Does not observe __proto__", function(assert) {
 	let records = ObservationRecorder.stop();
 	let deps = Array.from(records.keyDependencies);
 	assert.equal(deps.length, 0, "Nothing recorded just by calling super.fn()");
+});
+
+QUnit.test("Self-referential typing", function(assert) {
+	class Faves extends DefineObject {
+		static get define() {
+			return {
+				faves: type.late(() => type.convert(Faves))
+			};
+		}
+	}
+
+	let faves = new Faves({
+		faves: {}
+	});
+
+	assert.ok(faves instanceof Faves);
+	assert.ok(faves.faves instanceof Faves);
 });


### PR DESCRIPTION
This makes late types and defers to `type.normalize` in order to get
default type behavior.