### PR TITLE
Add value, oldValue, action, key to event object

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
-    "can-reflect-tests": "^0.3.1",
+    "can-reflect-tests": "^1.0.0",
     "can-test-helpers": "^1.1.4",
     "detect-cyclic-packages": "^1.1.0",
     "fixpack": "^2.3.1",

--- a/src/define-helpers.js
+++ b/src/define-helpers.js
@@ -88,6 +88,7 @@ const defineHelpers = {
 			delete this[prop];
 			queues.batch.start();
 			this.dispatch({
+				action: "can.keys",
 				type: "can.keys",
 				target: this
 			});
@@ -96,6 +97,9 @@ const defineHelpers = {
 				delete this._data[prop];
 				//delete this[prop];
 				this.dispatch({
+					action: "delete",
+					key: prop,
+					oldValue: oldValue,
 					type: prop,
 					target: this,
 					patches: [{type: "delete", key: prop}],

--- a/src/define.js
+++ b/src/define.js
@@ -412,6 +412,7 @@ define.makeDefineInstanceKey = function(constructor) {
 		}
 
 		this.prototype.dispatch({
+			action: "can.keys",
 			type: "can.keys",
 			target: this.prototype
 		});
@@ -448,6 +449,10 @@ make = {
 				computeObj.oldValue = newVal;
 
 				map.dispatch({
+					action: "prop",
+					key: prop,
+					value: newVal,
+					oldValue: oldValue,
 					type: prop,
 					target: map
 				}, [newVal, oldValue]);
@@ -525,6 +530,10 @@ make = {
 
 						dispatched = {
 							patches: [{type: "set", key: prop, value: newVal}],
+							action: "prop",
+							key: prop,
+							value: newVal,
+							oldValue: current,
 							type: prop,
 							target: this
 						};
@@ -548,6 +557,10 @@ make = {
 				if (newVal !== current) {
 					var dispatched = {
 						patches: [{type: "set", key: prop, value: newVal}],
+						action: "prop",
+						key: prop,
+						value: newVal,
+						oldValue: current,
 						type: prop,
 						target: map
 					};
@@ -1113,18 +1126,24 @@ define.expando = function(map, prop, value) {
 		if(!map[inSetupSymbol]) {
 			queues.batch.start();
 			map.dispatch({
+				action: "can.keys",
 				type: "can.keys",
 				target: map
 			});
 			if(Object.prototype.hasOwnProperty.call(map._data, prop)) {
 				map.dispatch({
+					action: "add",
+					key: prop,
 					type: prop,
+					value: map._data[prop],
 					target: map,
 					patches: [{type: "add", key: prop, value: map._data[prop]}],
 				},[map._data[prop], undefined]);
 			} else {
 				map.dispatch({
+					action: "set",
 					type: "set",
+					value: map._data[prop],
 					target: map,
 					patches: [{type: "add", key: prop, value: map._data[prop]}],
 				},[map._data[prop], undefined]);

--- a/test/props-mixin-proxy-object-test.js
+++ b/test/props-mixin-proxy-object-test.js
@@ -99,3 +99,64 @@ QUnit.test("Self-referential typing", function(assert) {
 	assert.ok(faves instanceof Faves);
 	assert.ok(faves.faves instanceof Faves);
 });
+
+QUnit.test("oldValue and value are on event object", function(assert) {
+	assert.expect(2);
+
+	class Faves extends ObservableObject {
+		static get props() {
+			return {
+				prop: String
+			};
+		}
+	}
+
+	let faves = new Faves({ prop: "value" });
+
+	faves.listenTo("prop", (ev) => {
+		assert.equal(ev.value, "value2", "has the new value");
+		assert.equal(ev.oldValue, "value", "has the old value");
+	});
+
+	faves.prop = "value2";
+});
+
+QUnit.test("deleteKey includes the oldValue", function(assert) {
+	assert.expect(1);
+
+	class Faves extends ObservableObject {
+		static get props() {
+			return {
+				prop: type.Any
+			};
+		}
+	}
+
+	let faves = new Faves({ prop: "value" });
+	faves.listenTo("prop", ev => {
+		assert.equal(ev.oldValue, "value", "includes the old value");
+	});
+	faves.deleteKey("prop");
+});
+
+QUnit.test("Changes in getters includes the old and new values", function(assert) {
+	class Faves extends ObservableObject {
+		static get props() {
+			return {
+				one: String,
+				two: {
+					get() {
+						return this.one;
+					}
+				}
+			};
+		}
+	}
+
+	let faves = new Faves({ one: "one" });
+	faves.listenTo("one", ev => {
+		assert.equal(ev.value, "two", "has the new value");
+		assert.equal(ev.oldValue, "one", "Has the old value");
+	});
+	faves.one = "two";
+});

--- a/test/type-events-test.js
+++ b/test/type-events-test.js
@@ -8,3 +8,9 @@ QUnit.module("can-observable-mixin Type events");
 require("can-reflect-tests/observables/map-like/type/type")("Defined", function(){
 	return class Type extends mixinObject() {};
 });
+
+require("can-reflect-tests/observables/map-like/instance/on-event-get-set-delete-key")("ObservableObject", function(){
+	class Type extends mixinObject() {}
+
+	return new Type();
+});


### PR DESCRIPTION
This adds new properties to the events object, in anticipation of a
future breaking change where the events object will be the only
argument. Closes #119