### PR TITLE
Avoids use of ES Proxy (or Symbol) where not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "can-reflect": "^1.17.9",
     "can-simple-observable": "^2.4.1",
     "can-string-to-any": "^1.2.0",
+    "can-symbol": "^1.6.0",
     "can-type": "^0.1.3"
   },
   "devDependencies": {

--- a/src/mixin-proxy.js
+++ b/src/mixin-proxy.js
@@ -87,9 +87,7 @@ function proxyPrototype(Base) {
 		}
 	};
 
-	LateDefined.prototype = (typeof Proxy === "function")
-		? new Proxy(underlyingPrototypeObject, proxyHandlers)
-		: underlyingPrototypeObject;
+	LateDefined.prototype = (typeof Proxy === "function") ? new Proxy(underlyingPrototypeObject, proxyHandlers) : underlyingPrototypeObject;
 
 	return LateDefined;
 }


### PR DESCRIPTION
Fixes #125 in the `can-define-mixin-legacy` branch

- Avoids use of ES Proxy when not supported.
- Prints one-time warning when using mixin-proxy in browsers that do not support ES Proxies.
- Uses `can-symbol` instead of directly using ES Symbol.

NOTE:
No idea why there are four failing unit tests, but it does not look like anything related to the updated code. No idea how to verify if they were already broken before changes, because the unit tests fail to run on Windows.