### PR TITLE
Avoids use of ES Proxies when not supported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "can-reflect": "^1.17.9",
     "can-simple-observable": "^2.4.1",
     "can-string-to-any": "^1.2.0",
+    "can-symbol": "^1.6.0",
     "can-type": "^1.0.0-pre.2"
   },
   "devDependencies": {

--- a/src/mixin-proxy.js
+++ b/src/mixin-proxy.js
@@ -1,8 +1,11 @@
 const defineBehavior = require("./define");
 const ObservationRecorder = require("can-observation-recorder");
+const canSymbol = require( "can-symbol" );
 
 const eventDispatcher = defineBehavior.make.set.eventDispatcher;
-const inSetupSymbol = Symbol.for("can.initializing");
+const inSetupSymbol = canSymbol.for("can.initializing");
+
+const canLogDev = require("can-log/dev/dev");
 
 // A bug in Safari means that __proto__ key is sent. This causes problems
 // When addEventListener is called on a non-element.
@@ -22,10 +25,24 @@ let isProtoReadOnSuper = false;
 	}
 })();
 
+let wasLogged = false;
+function logNotSupported() {
+	if (!wasLogged && (typeof Proxy !== "function")) {
+		wasLogged = true;
+		canLogDev.warn("can-observable-mixin/mixin-proxy requires ES Proxies which are not supported by your JS runtime.");
+	}
+}
+
 function proxyPrototype(Base) {
 	const instances = new WeakSet();
 
 	function LateDefined() {
+		//!steal-remove-start
+		if(process.env.NODE_ENV !== "production") {
+			logNotSupported();
+		}
+		//!steal-remove-end
+
 		let inst = Reflect.construct(Base, arguments, new.target);
 		instances.add(inst);
 		return inst;
@@ -70,7 +87,10 @@ function proxyPrototype(Base) {
 		}
 	};
 
-	LateDefined.prototype = new Proxy(underlyingPrototypeObject, proxyHandlers);
+	LateDefined.prototype = (typeof Proxy === "function") ?
+		new Proxy(underlyingPrototypeObject, proxyHandlers) :
+		underlyingPrototypeObject;
+
 	return LateDefined;
 }
 


### PR DESCRIPTION
Also prints one-time warning when using mixin-proxy in browsers that do not support ES Proxies.

closes https://github.com/canjs/can-observable-mixin/issues/125