### PR TITLE
making async and value behaviors non-enumerable by default

### DIFF
--- a/src/define.js
+++ b/src/define.js
@@ -227,6 +227,13 @@ var callAsync = function(fn) {
 
 define.extensions = function () {};
 
+define.isEnumerable = function(definition) {
+	return typeof definition !== "object" ||
+		("serialize" in definition ?
+			!!definition.serialize :
+			(!definition.get && !definition.async && !definition.value));
+};
+
 // typePrototype - the prototype of the type we are defining `prop` on.
 // `definition` - the user provided definition
 define.property = function(typePrototype, prop, definition, dataInitializers, computedInitializers, defaultDefinition) {
@@ -389,7 +396,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 	Object_defineNamedPrototypeProperty(typePrototype, prop, {
 		get: getter,
 		set: setter,
-		enumerable: "serialize" in definition ? !!definition.serialize : !definition.get,
+		enumerable: define.isEnumerable(definition),
 		configurable: true
 	});
 };

--- a/src/mixin-mapprops.js
+++ b/src/mixin-mapprops.js
@@ -1,5 +1,5 @@
 const addDefinedProps = require("./define");
-const { updateSchemaKeys, hooks } = addDefinedProps;
+const { updateSchemaKeys, hooks, isEnumerable } = addDefinedProps;
 
 const defineHelpers = require("./define-helpers");
 const ObservationRecorder = require("can-observation-recorder");
@@ -10,10 +10,9 @@ const queues = require("can-queues");
 const getSchemaSymbol = Symbol.for("can.getSchema");
 
 function keysForDefinition(definitions) {
-	var keys = [];
-	for(var prop in definitions) {
-		var definition = definitions[prop];
-		if(typeof definition !== "object" || ("serialize" in definition ? !!definition.serialize : !definition.get)) {
+	const keys = [];
+	for(let prop in definitions) {
+		if(isEnumerable(definitions[prop])) {
 			keys.push(prop);
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/canjs/can-observable-mixin/issues/129.