### PR TITLE
Implement the can.unwrap symbol

### DIFF
--- a/src/mixin-mapprops.js
+++ b/src/mixin-mapprops.js
@@ -190,6 +190,10 @@ module.exports = function(Type) {
 			return defineHelpers.reflectSerialize.apply(this, args);
 		}
 
+		[Symbol.for("can.unwrap")](...args) {
+			return defineHelpers.reflectUnwrap.apply(this, args);
+		}
+
 		[Symbol.for("can.hasKey")](key) {
 			return (key in this._define.definitions) || (this._instanceDefinitions !== undefined && key in this._instanceDefinitions);
 		}

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -147,3 +147,18 @@ QUnit.test("should not serialize properties using value and get behaviors unless
 	let expected = { prop: "b", propGetter: "b", propValue: "b", propAsync: "b" };
 	assert.deepEqual(obj.serialize(), expected, "all props are serialized");
 });
+
+QUnit.test("should implement can.unwrap", function(assert) {
+	class Obj extends mixinObject() {
+		static get props() {
+			return {
+				definedValue: String,
+				undefinedValue: String
+			};
+		}
+	}
+
+	const obj = new Obj({ definedValue: "a" });
+
+	assert.deepEqual(canReflect.unwrap(obj), { definedValue: "a" }, "undefined props are not returned by unwrap");
+});


### PR DESCRIPTION
This adds the `can.unwrap` symbol to the mixin’s implementation so `canReflect.unwrap` can get an object without `undefined` values, matching `can-define/map/map`’s behavior.

Needed as part of https://github.com/canjs/canjs/issues/5207