### PR TITLE
Include onEvent in Type events mixin

### DIFF
--- a/src/mixin-typeevents.js
+++ b/src/mixin-typeevents.js
@@ -1,8 +1,10 @@
 const addTypeEvents  = require("can-event-queue/type/type");
+const addMapEvents  = require("can-event-queue/map/map");
 
 function mixinTypeEvents(Type) {
 	let Child = class extends Type {};
 	addTypeEvents(Child);
+	addMapEvents(Child);
 	return Child;
 }
 

--- a/test/type-events-test.js
+++ b/test/type-events-test.js
@@ -2,6 +2,7 @@
 
 const QUnit = require("steal-qunit");
 const { mixinObject } = require("./helpers");
+const canReflect = require('can-reflect');
 
 QUnit.module("can-observable-mixin Type events");
 
@@ -13,4 +14,18 @@ require("can-reflect-tests/observables/map-like/instance/on-event-get-set-delete
 	class Type extends mixinObject() {}
 
 	return new Type();
+});
+
+QUnit.test("ObservableObject has onEvent", function(assert){
+	assert.expect(3);
+
+	class Type extends mixinObject() {}
+
+	assert.notOk( canReflect.isBound(Type), "not bound");
+	canReflect.onEvent(Type, "created", function(event){
+		assert.ok( true, "event occured");
+	});
+	assert.ok( canReflect.isBound(Type), "bound");
+
+	Type.dispatch('created', {foo:'bar'});
 });

--- a/test/type-events-test.js
+++ b/test/type-events-test.js
@@ -22,7 +22,7 @@ QUnit.test("ObservableObject has onEvent", function(assert){
 	class Type extends mixinObject() {}
 
 	assert.notOk( canReflect.isBound(Type), "not bound");
-	canReflect.onEvent(Type, "created", function(event){
+	canReflect.onEvent(Type, "created", function(){
 		assert.ok( true, "event occured");
 	});
 	assert.ok( canReflect.isBound(Type), "bound");


### PR DESCRIPTION
I noticed that classes that extend ObservableObject aren't able to be event targets since they don't implement the `onKeyValue` or `onEvent` symbols. Trying to set up a listener for an event on the class results in an error, e.g:
```
class Todo extends ObservableObject {
    ...
}

class CreatedTodos extends StacheElement {
  ...
  connected() {
    this.listenTo(Todo, "created", (ev, created) => {
      this.todos.unshift(created);
    })
  }
}
```
This will cause the error "Uncaught Error: can-event-queue: Unable to bind created".

To resolve this Justin suggested I add the `can-event-queue/map/map` mixin to `mixin-typeevents.js`.