### PR TITLE
Add createConstructorFunction helper

### DIFF
--- a/src/create-constructor-function.js
+++ b/src/create-constructor-function.js
@@ -1,0 +1,59 @@
+/**
+ * Creates a constructor function from an ES2015 class, this is a workaround
+ * needed to being able to extend a class from code that's transpiled by Babel.
+ * See https://github.com/babel/babel/pull/8656
+ * @param {*} Type The ES2015 base class used to create the constructor
+ * @param {*} Parent The object where the prototype chain walk to copy over
+ * symbols and static properties to the constructor stops. If not provided,
+ * the chain stops at Object.
+ * @returns {Function} Constructor function than can be safely subclassed from
+ * transpiled code.
+ */
+function createConstructorFunction(Type, Parent) {
+	if (typeof Parent === "undefined") {
+		Parent = Object.getPrototypeOf(Object);
+	}
+
+	function TypeConstructor() {
+		return Reflect.construct(Type, arguments, this.constructor);
+	}
+
+	TypeConstructor.prototype = Object.create(Type.prototype);
+	TypeConstructor.prototype.constructor = TypeConstructor;
+
+	/**
+	 * Add `prop` to TypeConstructor from `source` if not defined already
+	 * @param {{}} source The object that owns `prop`
+	 * @param {string} prop The name of the property to be defined
+	 */
+	function copyIfMissing(source, prop) {
+		if (!TypeConstructor[prop]) {
+			Object.defineProperty(
+				TypeConstructor,
+				prop,
+				Object.getOwnPropertyDescriptor(source, prop)
+			);
+		}
+	}
+
+	// Walk up the prototype chain to copy over all Symbols and
+	// static properties to the constructor function
+	let Link = Type;
+	while (Link !== Parent && Link !== null) {
+		const props = Object.getOwnPropertyNames(Link);
+		props.forEach(function(prop) {
+			copyIfMissing(Link, prop);
+		});
+
+		const symbols = Object.getOwnPropertySymbols(Link);
+		symbols.forEach(function(symbol) {
+			copyIfMissing(Link, symbol);
+		});
+
+		Link = Object.getPrototypeOf(Link);
+	}
+
+	return TypeConstructor;
+}
+
+module.exports = createConstructorFunction;

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -1,8 +1,11 @@
+const createConstructorFunction = require("./create-constructor-function");
 const defineBehavior = require("./define");
 const mixinElement = require("./mixin-element");
 const mixinMapProps = require("./mixin-mapprops");
 const mixinProxy = require("./mixin-proxy");
 const mixinTypeEvents = require("./mixin-typeevents");
+
+exports.createConstructorFunction = createConstructorFunction;
 
 exports.makeDefineInstanceKey = defineBehavior.makeDefineInstanceKey;
 exports.mixins = defineBehavior.hooks;

--- a/test/create-constructor-function-test.js
+++ b/test/create-constructor-function-test.js
@@ -1,0 +1,114 @@
+const QUnit = require("steal-qunit");
+const { createConstructorFunction } = require("../src/mixins");
+
+QUnit.module("can-observable-mixin - createConstructorFunction");
+
+QUnit.test("basics", function(assert) {
+	class Foo {
+		static get bar() {
+			return "bar";
+		}
+		static getIndex() {
+			return 0;
+		}
+		static get [Symbol.species]() {
+			return this;
+		}
+	}
+
+	const FooConstructor = createConstructorFunction(Foo);
+
+	assert.equal(FooConstructor.bar, "bar", "should keep static props");
+	assert.ok(FooConstructor[Symbol.species], "should keep symbols");
+	assert.equal(FooConstructor.getIndex(), 0, "should keep static methods");
+});
+
+QUnit.test("walks up the prototype chain", function(assert) {
+	class Foo {
+		static get bar() {
+			return "bar";
+		}
+		static getIndex() {
+			return 0;
+		}
+		static get [Symbol.species]() {
+			return this;
+		}
+	}
+
+	const Bar = Object.create(Foo);
+	const BarConstructor = createConstructorFunction(Bar);
+
+	assert.equal(BarConstructor.bar, "bar", "should keep static props");
+	assert.ok(BarConstructor[Symbol.species], "should keep symbols");
+	assert.equal(BarConstructor.getIndex(), 0, "should keep static methods");
+});
+
+QUnit.test("it should keep static getters", function(assert) {
+	class Foo {
+		static get foo() {
+			return "foo";
+		}
+	}
+	const Bar = Object.create(Foo);
+	const BarConstructor = createConstructorFunction(Bar);
+	assert.equal(
+		BarConstructor.foo,
+		"foo",
+		"should keep the static foo getter"
+	);
+});
+
+QUnit.test("it should keep property descriptors", function(assert) {
+	class Foo {
+		static get foo() {
+			return "foo";
+		}
+	}
+	const Bar = Object.create(Foo);
+	const BarConstructor = createConstructorFunction(Bar);
+
+	assert.deepEqual(
+		Object.getOwnPropertyDescriptor(Foo, "foo"),
+		Object.getOwnPropertyDescriptor(BarConstructor, "foo"),
+		"should be the same descriptor"
+	);
+});
+
+QUnit.test("can stop prototype chain walk at indicated object", function(
+	assert
+) {
+	class Foo {
+		static get foo() {
+			return "bar";
+		}
+	}
+
+	const Bar = Object.create(Foo);
+	Bar.getIndex = () => 10;
+	Bar[Symbol.for("can.new")] = () => true;
+
+	const Baz = Object.create(Bar);
+	const BazConstructor = createConstructorFunction(Baz, Foo);
+
+	assert.equal(
+		typeof BazConstructor.foo,
+		"undefined",
+		"should not walk up to Foo"
+	);
+	assert.ok(BazConstructor[Symbol.for("can.new")], "should keep symbols");
+	assert.equal(BazConstructor.getIndex(), 10, "should keep static methods");
+});
+
+QUnit.test("Symbol.species should work on the constructor", function(assert) {
+	class MyArray extends Array {
+		static get [Symbol.species]() {
+			return Array;
+		}
+	}
+
+	const MyArrayConstructor = createConstructorFunction(MyArray);
+	const array = new MyArrayConstructor();
+
+	assert.ok(array instanceof Array);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+require("./create-constructor-function-test");
 require("./props-mixin-test");
 require("./props-test");
 require("./props-types-test");


### PR DESCRIPTION
This helper will allow us to take ES2015 classes and return
constructor functions that can be extended in code that is transpiled
with Babel. The helper should be deprecated once Babel transpiled code
can extend from native classes without errors.