### PR TITLE
Improve type error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "can-queues": "^1.2.1",
     "can-reflect": "^1.17.9",
     "can-simple-observable": "^2.5.0",
-    "can-string": "^1.1.0",
     "can-string-to-any": "^1.2.0",
     "can-symbol": "^1.6.0",
     "can-type": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "can-queues": "^1.2.1",
     "can-reflect": "^1.17.9",
     "can-simple-observable": "^2.5.0",
+    "can-string": "^1.1.0",
     "can-string-to-any": "^1.2.0",
     "can-symbol": "^1.6.0",
     "can-type": "^1.0.0"

--- a/src/define.js
+++ b/src/define.js
@@ -18,7 +18,6 @@ var canLogDev = require("can-log/dev/dev");
 
 var defineLazyValue = require("can-define-lazy-value");
 var type = require("can-type");
-var canString = require('can-string');
 
 var newSymbol = Symbol.for("can.new"),
 	serializeSymbol = Symbol.for("can.serialize"),
@@ -691,14 +690,15 @@ make = {
 				} else {
 					return function setter(newValue){
 						//!steal-remove-start
-						try {
-							return set.call(this, canReflect.convert(newValue, type));
-						} catch (error) {
-							var typeName = canReflect.getName(type[baseTypeSymbol]);
-							var propType = canString.capitalize(typeof prop);
-							var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + propType + '". ';
-							message += 'Use "' + prop + ': type.convert(' + typeName + ')" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
-							throw new Error(message);
+						if(process.env.NODE_ENV !== 'production') {
+							try {
+								return set.call(this, canReflect.convert(newValue, type));
+							} catch (error) {
+								var typeName = canReflect.getName(type[baseTypeSymbol]);
+								var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + typeName + '". ';
+								message += 'Use "' + prop + ': type.convert(' + typeName + ')" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
+								throw new Error(message);
+							}
 						}
 						//!steal-remove-end
 						return set.call(this, canReflect.convert(newValue, type));

--- a/src/define.js
+++ b/src/define.js
@@ -696,7 +696,8 @@ make = {
 						} catch (error) {
 							var typeName = canReflect.getName(type[baseTypeSymbol]);
 							var propType = canString.capitalize(typeof prop);
-							var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using type: ' + propType;
+							var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + propType + '". ';
+							message += 'Use "' + prop + ': type.To' + typeName + '" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
 							throw new Error(message);
 						}
 					};

--- a/src/define.js
+++ b/src/define.js
@@ -18,13 +18,15 @@ var canLogDev = require("can-log/dev/dev");
 
 var defineLazyValue = require("can-define-lazy-value");
 var type = require("can-type");
+var canString = require('can-string');
 
 var newSymbol = Symbol.for("can.new"),
 	serializeSymbol = Symbol.for("can.serialize"),
 	inSetupSymbol = Symbol.for("can.initializing"),
 	isMemberSymbol = Symbol.for("can.isMember"),
 	hasBeenDefinedSymbol = Symbol.for("can.hasBeenDefined"),
-	canMetaSymbol = Symbol.for("can.meta");
+	canMetaSymbol = Symbol.for("can.meta"),
+	baseTypeSymbol = Symbol.for("can.baseType");
 
 var eventsProto, define,
 	make, makeDefinition, getDefinitionsAndMethods, getDefinitionOrMethod;
@@ -688,7 +690,15 @@ make = {
 					return setter;
 				} else {
 					return function setter(newValue){
-						return set.call(this, canReflect.convert(newValue, type));
+						try {
+							var val = canReflect.convert(newValue, type);
+							return set.call(this, val);
+						} catch (error) {
+							var typeName = canReflect.getName(type[baseTypeSymbol]);
+							var propType = canString.capitalize(typeof prop);
+							var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using type: ' + propType;
+							throw new Error(message);
+						}
 					};
 				}
 			}

--- a/src/define.js
+++ b/src/define.js
@@ -697,7 +697,7 @@ make = {
 							var typeName = canReflect.getName(type[baseTypeSymbol]);
 							var propType = canString.capitalize(typeof prop);
 							var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + propType + '". ';
-							message += 'Use "' + prop + ': type.To' + typeName + '" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
+							message += 'Use "' + prop + ': type.convert(' + typeName + ')" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
 							throw new Error(message);
 						}
 						//!steal-remove-end

--- a/src/define.js
+++ b/src/define.js
@@ -690,9 +690,9 @@ make = {
 					return setter;
 				} else {
 					return function setter(newValue){
+						//!steal-remove-start
 						try {
-							var val = canReflect.convert(newValue, type);
-							return set.call(this, val);
+							return set.call(this, canReflect.convert(newValue, type));
 						} catch (error) {
 							var typeName = canReflect.getName(type[baseTypeSymbol]);
 							var propType = canString.capitalize(typeof prop);
@@ -700,6 +700,8 @@ make = {
 							message += 'Use "' + prop + ': type.To' + typeName + '" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
 							throw new Error(message);
 						}
+						//!steal-remove-end
+						return set.call(this, canReflect.convert(newValue, type));
 					};
 				}
 			}

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -3,6 +3,7 @@ const { mixinObject } = require("./helpers");
 const { hooks } = require("../src/define");
 const canReflect = require("can-reflect");
 const type = require('can-type');
+const dev = require("can-test-helpers").dev;
 
 QUnit.module("can-observable-mixin - define()");
 
@@ -190,7 +191,7 @@ QUnit.test("properties using value behavior reset when unbound", function(assert
 	assert.equal(obj.derivedProp, undefined, "value reset");
 });
 
-QUnit.test('On error include the name of the property that is being set', function(assert) {
+dev.devOnlyTest('On error include the name of the property that is being set', function(assert) {
 	class Person extends mixinObject() {
 		static get props() {
 			return {

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -2,6 +2,7 @@ const QUnit = require("steal-qunit");
 const { mixinObject } = require("./helpers");
 const { hooks } = require("../src/define");
 const canReflect = require("can-reflect");
+const type = require('can-type');
 
 QUnit.module("can-observable-mixin - define()");
 
@@ -187,4 +188,22 @@ QUnit.test("properties using value behavior reset when unbound", function(assert
 	obj.stopListening();
 
 	assert.equal(obj.derivedProp, undefined, "value reset");
+});
+
+QUnit.test('On error include the name of the property that is being set', function(assert) {
+	class Person extends mixinObject() {
+		static get props() {
+			return {
+				age: type.check(Number)
+			};
+		}
+	}
+
+	var farah = new Person();
+	
+	try {
+		farah.age = '4';
+	} catch (error) {
+		assert.equal(error.message, '4 is not of type Number. Property age is using type: String');
+	}
 });

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -204,6 +204,6 @@ QUnit.test('On error include the name of the property that is being set', functi
 	try {
 		farah.age = '4';
 	} catch (error) {
-		assert.equal(error.message, '4 is not of type Number. Property age is using type: String');
+		assert.equal(error.message, '4 is not of type Number. Property age is using "type: String". Use "age: type.ToNumber" to automatically convert values to Numbers when setting the "age" property.');
 	}
 });

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -205,6 +205,6 @@ dev.devOnlyTest('On error include the name of the property that is being set', f
 	try {
 		farah.age = '4';
 	} catch (error) {
-		assert.equal(error.message, '4 is not of type Number. Property age is using "type: String". Use "age: type.convert(Number)" to automatically convert values to Numbers when setting the "age" property.');
+		assert.equal(error.message, '4 is not of type Number. Property age is using "type: Number". Use "age: type.convert(Number)" to automatically convert values to Numbers when setting the "age" property.');
 	}
 });

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -205,6 +205,6 @@ dev.devOnlyTest('On error include the name of the property that is being set', f
 	try {
 		farah.age = '4';
 	} catch (error) {
-		assert.equal(error.message, '4 is not of type Number. Property age is using "type: String". Use "age: type.ToNumber" to automatically convert values to Numbers when setting the "age" property.');
+		assert.equal(error.message, '4 is not of type Number. Property age is using "type: String". Use "age: type.convert(Number)" to automatically convert values to Numbers when setting the "age" property.');
 	}
 });


### PR DESCRIPTION
This fixes 2 and 3 in the issue https://github.com/canjs/canjs/issues/5310:

```js
class Person extends mixinObject() {
    static get props() {
       return {
         age: type.check(Number)
       };
    }
}
var farah = new Person();
farah.age = '4'; // -> `Uncaught Error: 4 is not of type Number. Property age is using "type: String". Use "age: type.ToNumber" to automatically convert values to Numbers when setting the "age" property.`
```