### PR TITLE
Error message improvment for arrays

### DIFF
--- a/src/define.js
+++ b/src/define.js
@@ -695,6 +695,9 @@ make = {
 								return set.call(this, canReflect.convert(newValue, type));
 							} catch (error) {
 								var typeName = canReflect.getName(type[baseTypeSymbol]);
+								if (Array.isArray(newValue)) {
+									newValue = '[' + newValue + ']';
+								}
 								var message  = newValue +  ' is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + typeName + '". ';
 								message += 'Use "' + prop + ': type.convert(' + typeName + ')" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
 								throw new Error(message);

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -208,3 +208,22 @@ dev.devOnlyTest('On error include the name of the property that is being set', f
 		assert.equal(error.message, '4 is not of type Number. Property age is using "type: Number". Use "age: type.convert(Number)" to automatically convert values to Numbers when setting the "age" property.');
 	}
 });
+
+
+dev.devOnlyTest('Better error message for Right-hand side of instanceof is not callable for arrays', function(assert) {
+	class Foo extends mixinObject() {
+		static get props() {
+			return {
+				list: []
+			};
+		}
+	}
+	var foo = new Foo();
+
+	try {
+		foo.list = [ "one", "two" ];
+
+	} catch (error) {
+		assert.equal(error.message, '[one,two] is not of type Array[]. Property list is using "type: Array[]". Use "list: type.convert(Array[])" to automatically convert values to Array[]s when setting the "list" property.');
+	}
+});


### PR DESCRIPTION
This improves the type error message for arrays:

```js
class Foo extends mixinObject() {
    static get props() {
       return {
	     list: []
       };
    }
}

var foo = new Foo();  
foo.list = [ "one", "two" ]; // -> [one,two] is not of type Array[]. Property list is using "type: Array[]". Use "list: type.convert(Array[])" to automatically convert values to Array[]s when setting the "list" property.
```