### PR TITLE
Only type errors should be catched

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "can-simple-observable": "^2.5.0",
     "can-string-to-any": "^1.2.0",
     "can-symbol": "^1.6.0",
-    "can-type": "^1.0.3"
+    "can-type": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "can-simple-observable": "^2.5.0",
     "can-string-to-any": "^1.2.0",
     "can-symbol": "^1.6.0",
-    "can-type": "^1.0.0"
+    "can-type": "^1.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/define.js
+++ b/src/define.js
@@ -694,11 +694,15 @@ make = {
 							try {
 								return set.call(this, canReflect.convert(newValue, type));
 							} catch (error) {
-								var typeName = canReflect.getName(type[baseTypeSymbol]);
-								var valueType = typeof newValue;
-								var message  = '"' + newValue + '"' +  ' ('+ valueType + ') is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + typeName + '". ';
-								message += 'Use "' + prop + ': type.convert(' + typeName + ')" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
-								throw new Error(message);
+								if (error.type === 'can-type-error') {
+									var typeName = canReflect.getName(type[baseTypeSymbol]);
+									var valueType = typeof newValue;
+									var message  = '"' + newValue + '"' +  ' ('+ valueType + ') is not of type ' + typeName + '. Property ' + prop + ' is using "type: ' + typeName + '". ';
+									message += 'Use "' + prop + ': type.convert(' + typeName + ')" to automatically convert values to ' + typeName + 's when setting the "' + prop + '" property.';
+									throw new Error(message);
+								} else {
+									throw error;
+								}
 							}
 						}
 						//!steal-remove-end

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -3,19 +3,20 @@ const { mixinObject } = require("./helpers");
 const { hooks } = require("../src/define");
 const canReflect = require("can-reflect");
 const type = require('can-type');
+const Observation = require('can-observation');
 const dev = require("can-test-helpers").dev;
 
 QUnit.module("can-observable-mixin - define()");
 
 QUnit.test("Can define stuff", function(assert) {
   class Faves extends mixinObject() {
-    static get props() {
-      return {
+	static get props() {
+	  return {
 			color: {
 				default: "blue"
 			}
-      };
-    }
+	  };
+	}
   }
 
   let faves = new Faves();
@@ -30,13 +31,13 @@ QUnit.test("Does not throw if no define is provided", function(assert) {
 
 QUnit.test("Stuff is defined in constructor for non-element classes", function(assert) {
   class Faves extends mixinObject(Object) {
-    static get props() {
-      return {
+	static get props() {
+	  return {
 			color: {
 				default: "blue"
 			}
-      };
-    }
+	  };
+	}
 
 	constructor() {
 		super();
@@ -226,3 +227,34 @@ dev.devOnlyTest('Handle types as arrays to fix "Right-hand side of instanceof is
 		assert.ok(error.message);
 	}
 });
+
+dev.devOnlyTest('Only can-type error should be catched', function(assert) {
+	class T extends mixinObject() {
+		static get props() {
+			return  {
+				aStr: {
+					type: type.maybe(String),
+					default: "Hi"
+				},
+				get foo() {
+					return this.aStr.toUpperCase();
+				}
+			};
+		}
+	}
+
+	var t = new T();
+
+	var obs = new Observation(function() {
+		return t.foo;
+	});
+	canReflect.onValue(obs, function() {});
+	
+	try {
+		t.aStr = null;
+	} catch (error) {
+		assert.equal(error.type, undefined, 'can-type error only thrown on wrong types');
+	}
+	
+});
+


### PR DESCRIPTION
The fix check if the error has `error.type` property equal `can-type-error` to catch it and enhance the error message otherwise the original error will be thrown. 

Fixes #147 