### PR TITLE
Define properties default value as null or undefined

### DIFF
--- a/src/define.js
+++ b/src/define.js
@@ -890,7 +890,11 @@ makeDefinition = function(prop, def, defaultDefinition, typePrototype) {
 		}
 
 		if (canReflect.isPrimitive(definition.default) && noTypeDefined) {
-			definition.type = type.normalize(definition.default.constructor);
+			if (definition.default === null || typeof definition.default === 'undefined') {
+				definition.type = type.Any;
+			} else {
+				definition.type = type.normalize(definition.default.constructor);
+			}
 		}
 	}
 

--- a/src/define.js
+++ b/src/define.js
@@ -921,14 +921,20 @@ makeDefinition = function(prop, def, defaultDefinition, typePrototype) {
 getDefinitionOrMethod = function(prop, value, defaultDefinition, typePrototype){
 	// Clean up the value to make it a definition-like object
 	var definition;
+	var definitionType;
 	if(canReflect.isPrimitive(value)) {
-		definition = {
-			default: value,
+		if (value === null || typeof value === 'undefined') {
+			definitionType = type.Any;
+		} else {
 			// only include type from defaultDefininition
 			// if it came from propertyDefaults
-			type: defaultDefinition.typeSetByDefault ?
+			definitionType = defaultDefinition.typeSetByDefault ?
 				type.normalize(value.constructor) :
-				defaultDefinition.type
+				defaultDefinition.type;
+		}
+		definition = {
+			default: value,
+			type: definitionType
 		};
 	}
     // copies a `Type`'s methods over

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -310,3 +310,20 @@ QUnit.test('Define default property null or undefined', function (assert) {
 	assert.equal(foo.nullProp, null);
 	assert.equal(foo.nullProp, undefined);
 });
+
+
+QUnit.test('Define property null or undefined', function (assert) {
+	class Foo extends mixinObject() {
+		static get props() {
+			return {
+				nullProp: null,
+				undefinedProp: null
+			};
+		}
+	}
+
+	var foo = new Foo();
+
+	assert.equal(foo.nullProp, null);
+	assert.equal(foo.nullProp, undefined);
+});

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -295,3 +295,18 @@ dev.devOnlyTest("Raise error if value, getter or setter aren't functions", funct
 	assert.equal(undo(), 3, "Errored on the non-function define arguments.");
 });
 
+QUnit.test('Define default property null or undefined', function (assert) {
+	class Foo extends mixinObject() {
+		static get props() {
+			return {
+				nullProp: { default: null },
+				undefinedProp: { default: undefined }
+			};
+		}
+	}
+
+	var foo = new Foo();
+
+	assert.equal(foo.nullProp, null);
+	assert.equal(foo.nullProp, undefined);
+});


### PR DESCRIPTION
This fix adds the ability to define properties with `null` or `undefined` default value:
```js
class Foo extends mixinObject() {
    static get props() {
          return {
	       nullProp: { default: null },
	       undefinedProp: { default: undefined }
	 };
    }
}

var foo = new Foo();
foo.nullProp; // -> null
foo.undefinedProp; // -> undefined
```

Closes #148 
