### PR TITLE
Replace `new.target` with `this.constructor`

### DIFF
--- a/src/mixin-proxy.js
+++ b/src/mixin-proxy.js
@@ -43,7 +43,7 @@ function proxyPrototype(Base) {
 		}
 		//!steal-remove-end
 
-		let inst = Reflect.construct(Base, arguments, new.target);
+		let inst = Reflect.construct(Base, arguments, this.constructor);
 		instances.add(inst);
 		return inst;
 	}


### PR DESCRIPTION
This addresses two issues that occur when using `new.target`:

- It's incompatible with Internet Explorer 11.
- It doesn't compile with any existing Babel plugins when using it with `Reflect.construct`, the way we are.

This change does mean that if somebody tries to extend the mixinProxy using `Object.create`, they will need to be sure to manually set the prototype correctly.